### PR TITLE
feat(arm64): support for arm64

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -26,7 +26,7 @@ jobs:
         runs-on: ubuntu-latest
         strategy:
           matrix:
-            architecture: [linux/amd64]
+            architecture: [linux/amd64,linux/arm64,linux/arm/v7]
         steps:
             - name: Checkout
               uses: actions/checkout@v2
@@ -53,10 +53,13 @@ jobs:
                 rm -rf /tmp/.buildx-cache/${{ matrix.architecture }}
                 mv /tmp/.buildx-cache-new/${{ matrix.architecture }} /tmp/.buildx-cache/${{ matrix.architecture }}
 
-    publish_amd64:
+    publish:
         needs: [test]
         runs-on: ubuntu-latest
         if: github.event_name != 'pull_request'
+        strategy:
+            matrix:
+                architecture: [linux/amd64,linux/arm64,linux/arm/v7]
         steps:
             - name: Checkout
               uses: actions/checkout@v2
@@ -69,18 +72,19 @@ jobs:
             - name: Cache amd64 Docker layers
               uses: actions/cache@v2
               with:
-                path: /tmp/.buildx-cache/linux/amd64
-                key: ${{ runner.os }}-buildx-linux/amd64-${{ github.sha }}
+                path: /tmp/.buildx-cache/${{ matrix.architecture }}
+                key: ${{ runner.os }}-buildx-${{ matrix.architecture }}-${{ github.sha }}
             - name: Docker meta
               id: meta
               uses: docker/metadata-action@v3
               with:
-                  images: revoltchat/server, ghcr.io/revoltchat/server
-            - name: Login to DockerHub
-              uses: docker/login-action@v1
-              with:
-                  username: ${{ secrets.DOCKERHUB_USERNAME }}
-                  password: ${{ secrets.DOCKERHUB_TOKEN }}
+#                  images: revoltchat/server, ghcr.io/revoltchat/server
+                    images: ghcr.io/redstonewizard08/delta
+#            - name: Login to DockerHub
+#              uses: docker/login-action@v1
+#              with:
+#                  username: ${{ secrets.DOCKERHUB_USERNAME }}
+#                  password: ${{ secrets.DOCKERHUB_TOKEN }}
             - name: Login to Github Container Registry
               uses: docker/login-action@v1
               with:
@@ -92,10 +96,10 @@ jobs:
               with:
                   context: .
                   push: true
-                  platforms: linux/amd64,linux/arm64,linux/arm/v7
+                  platforms: ${{ matrix.architecture }}
                   tags: ${{ steps.meta.outputs.tags }}
                   labels: ${{ steps.meta.outputs.labels }}
-                  cache-from: type=local,src=/tmp/.buildx-cache/linux/amd64
+                  cache-from: type=local,src=/tmp/.buildx-cache/${{ matrix.architecture }}
                   cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
             - name: Move cache
               run: |

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -70,7 +70,7 @@ jobs:
               uses: docker/setup-qemu-action@v1
             - name: Set up Docker Buildx
               uses: docker/setup-buildx-action@v1
-            - name: Cache amd64 Docker layers
+            - name: Cache Docker layers
               uses: actions/cache@v2
               with:
                 path: /tmp/.buildx-cache/${{ matrix.architecture }}
@@ -80,7 +80,7 @@ jobs:
               uses: docker/metadata-action@v3
               with:
 #                  images: revoltchat/server, ghcr.io/revoltchat/server
-                    images: ghcr.io/redstonewizard08/delta
+                    images: ghcr.io/redstonewizard08/delta/delta-${{ matrix.architecture }}
 #            - name: Login to DockerHub
 #              uses: docker/login-action@v1
 #              with:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -92,7 +92,7 @@ jobs:
               with:
                   context: .
                   push: true
-                  platforms: linux/amd64
+                  platforms: linux/amd64,linux/arm64,linux/arm/v7
                   tags: ${{ steps.meta.outputs.tags }}
                   labels: ${{ steps.meta.outputs.labels }}
                   cache-from: type=local,src=/tmp/.buildx-cache/linux/amd64

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -27,7 +27,7 @@ jobs:
         runs-on: ubuntu-latest
         strategy:
           matrix:
-            architecture: [linux/amd64,linux/arm64,linux/arm/v7]
+            architecture: [linux/amd64,linux/arm64]
         steps:
             - name: Checkout
               uses: actions/checkout@v2

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -55,12 +55,12 @@ jobs:
                 mv /tmp/.buildx-cache-new/${{ matrix.architecture }} /tmp/.buildx-cache/${{ matrix.architecture }}
 
     publish:
-        needs: [test]
+        #needs: [test]
         runs-on: ubuntu-latest
         if: github.event_name != 'pull_request'
         strategy:
             matrix:
-                architecture: [linux/amd64,linux/arm64]
+                architecture: [amd64,arm64]
         steps:
             - name: Checkout
               uses: actions/checkout@v2
@@ -74,13 +74,13 @@ jobs:
               uses: actions/cache@v2
               with:
                 path: /tmp/.buildx-cache/${{ matrix.architecture }}
-                key: ${{ runner.os }}-buildx-${{ matrix.architecture }}-${{ github.sha }}
+                key: ${{ runner.os }}-buildx-linux/${{ matrix.architecture }}-${{ github.sha }}
             - name: Docker meta
               id: meta
               uses: docker/metadata-action@v3
               with:
 #                  images: revoltchat/server, ghcr.io/revoltchat/server
-                    images: ghcr.io/redstonewizard08/delta/delta-${{ matrix.architecture }}
+                    images: ghcr.io/redstonewizard08/delta/delta:${{ matrix.architecture }}
 #            - name: Login to DockerHub
 #              uses: docker/login-action@v1
 #              with:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -4,6 +4,7 @@ on:
     push:
         branches:
             - "master"
+            - "patch-1"
         tags:
             - "*"
         paths-ignore:
@@ -59,7 +60,7 @@ jobs:
         if: github.event_name != 'pull_request'
         strategy:
             matrix:
-                architecture: [linux/amd64,linux/arm64,linux/arm/v7]
+                architecture: [linux/amd64,linux/arm64]
         steps:
             - name: Checkout
               uses: actions/checkout@v2

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -80,7 +80,7 @@ jobs:
               uses: docker/metadata-action@v3
               with:
 #                  images: revoltchat/server, ghcr.io/revoltchat/server
-                    images: ghcr.io/redstonewizard08/delta/delta:${{ matrix.architecture }}
+                    images: ghcr.io/redstonewizard08/delta
 #            - name: Login to DockerHub
 #              uses: docker/login-action@v1
 #              with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 # Build Stage
-FROM rustlang/rust:nightly-slim AS builder
+#FROM rustlang/rust:nightly-slim AS builder
+FROM rustlang/rust:nightly-slim@sha256:7cab2f9ad67980b21258701f8ca9df2b89275a9fed9d1de02bfb35c3d4fd477e AS builder
 USER 0:0
 WORKDIR /home/rust/src
 


### PR DESCRIPTION
This PR is almost done! I'm just trying to solve compilation errors now. (Maybe it's the rust version, ***help wanted***.)

This is a PR to add support for arm64 machines (again). It will compile Delta for arm64 and amd64 using a matrix and it will make sure they are published to the registry. (ghcr.io for now).

The motivation for this is that I have an arm64 server and I am not going to get an amd64 server. I would like to use Revolt on the server in production mode.