### PR TITLE
Fixed username new line bypass & mention disrupt

### DIFF
--- a/crates/quark/src/impl/generic/users/user.rs
+++ b/crates/quark/src/impl/generic/users/user.rs
@@ -173,7 +173,7 @@ impl User {
         }
 
         // Ensure none of the following substrings show up in the username
-        const BLOCKED_SUBSTRINGS: &[&str] = &["@", "#", ":", "```", "\n"];
+        const BLOCKED_SUBSTRINGS: &[&str] = &["@", "#", ":", "```", "\n", "\r", "[", "]"]; // Both [  & ] can disrupt the mention
 
         for substr in BLOCKED_SUBSTRINGS {
             if username_lowercase.contains(substr) {


### PR DESCRIPTION
I'm not sure If blacklisting **[** & **]** is right but I'd recommend it also It looks like we are fixing the symptom rather than the cause. One way to fix this errors is by fixing the mention system(Which is I don't know how) and make it to not parse the strings like Discord.

## Please make sure to check the following tasks before opening and submitting a PR

* [X] I understand and have followed the [contribution guide](https://github.com/revoltchat/revolt/discussions/282)
* [X] I have tested my changes locally and they are working as intended
* [X] These changes do not have any notable side effects on other Revolt projects
