### PR TITLE
feat: add `chat_status` field to user status

### DIFF
--- a/crates/delta/src/routes/users/edit_user.rs
+++ b/crates/delta/src/routes/users/edit_user.rs
@@ -97,6 +97,10 @@ pub async fn req(
             new_status.text = Some(text);
         }
 
+        if let Some(chat_status) = status.chat_status {
+            new_status.chat_status = Some(chat_status);
+        }
+
         if let Some(presence) = status.presence {
             new_status.presence = Some(presence);
         }

--- a/crates/quark/src/impl/generic/users/user.rs
+++ b/crates/quark/src/impl/generic/users/user.rs
@@ -48,6 +48,11 @@ impl User {
                     x.text = None;
                 }
             }
+            FieldsUser::StatusChat => {
+                if let Some(x) = self.status.as_mut() {
+                    x.chat_status = None;
+                }
+            }
             FieldsUser::StatusPresence => {
                 if let Some(x) = self.status.as_mut() {
                     x.presence = None;

--- a/crates/quark/src/impl/mongo/users/user.rs
+++ b/crates/quark/src/impl/mongo/users/user.rs
@@ -314,6 +314,7 @@ impl IntoDocumentPath for FieldsUser {
             FieldsUser::ProfileContent => "profile.content",
             FieldsUser::StatusPresence => "status.presence",
             FieldsUser::StatusText => "status.text",
+            FieldsUser::StatusChat => "status.chat_status",
         })
     }
 }

--- a/crates/quark/src/models/users/user.rs
+++ b/crates/quark/src/models/users/user.rs
@@ -51,6 +51,10 @@ pub struct UserStatus {
     #[validate(length(min = 1, max = 128))]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub text: Option<String>,
+    /// Custom status text that appears next to the username on chat messages
+    #[validate(length(min = 1, max = 32))]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub chat_status: Option<String>,
     /// Current presence option
     #[serde(skip_serializing_if = "Option::is_none")]
     pub presence: Option<Presence>,
@@ -167,6 +171,7 @@ pub struct User {
 pub enum FieldsUser {
     Avatar,
     StatusText,
+    StatusChat,
     StatusPresence,
     ProfileContent,
     ProfileBackground,


### PR DESCRIPTION
## Please make sure to check the following tasks before opening and submitting a PR

* [x] I understand and have followed the [contribution guide](https://github.com/revoltchat/revolt/discussions/282)
* [x] I have tested my changes locally and they are working as intended
* [x] These changes do not have any notable side effects on other Revolt projects
