### PR TITLE
fix: raise masquerade avatar URL length limit

### DIFF
--- a/crates/quark/src/models/channels/message.rs
+++ b/crates/quark/src/models/channels/message.rs
@@ -81,7 +81,7 @@ pub struct Masquerade {
     pub name: Option<String>,
     /// Replace the avatar shown on this message (URL to image file)
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[validate(length(min = 1, max = 128))]
+    #[validate(length(min = 1, max = 256))]
     pub avatar: Option<String>,
     /// Replace the display role colour shown on this message
     ///


### PR DESCRIPTION
## Please make sure to check the following tasks before opening and submitting a PR

* [x] I understand and have followed the [contribution guide](https://github.com/revoltchat/revolt/discussions/282)
* [ ] I have tested my changes locally and they are working as intended
* [x] These changes do not have any notable side effects on other Revolt projects

Discord server profile avatar URLs are longer than 128 characters. Raising the length limit would allow bridge bots to bridge server avatars.
