### PR TITLE
fix: deny access for bot creating a server

### DIFF
--- a/crates/delta/src/routes/servers/server_create.rs
+++ b/crates/delta/src/routes/servers/server_create.rs
@@ -44,6 +44,11 @@ pub async fn req(
     user: User,
     info: Json<DataCreateServer>,
 ) -> Result<Json<CreateServerResponse>> {
+
+    if user.bot.is_some() {
+        return Err(Error::IsBot);
+    }
+
     let info = info.into_inner();
     info.validate()
         .map_err(|error| Error::FailedValidation { error })?;

--- a/crates/delta/src/routes/servers/server_create.rs
+++ b/crates/delta/src/routes/servers/server_create.rs
@@ -44,7 +44,6 @@ pub async fn req(
     user: User,
     info: Json<DataCreateServer>,
 ) -> Result<Json<CreateServerResponse>> {
-
     if user.bot.is_some() {
         return Err(Error::IsBot);
     }


### PR DESCRIPTION
## Please make sure to check the following tasks before opening and submitting a PR

* [x] I understand and have followed the [contribution guide](https://github.com/revoltchat/revolt/discussions/282)
* [x] I have tested my changes locally and they are working as intended
* [x] These changes do not have any notable side effects on other Revolt projects
