### PR TITLE
Delta permissions clean-up

### DIFF
--- a/crates/delta/src/routes/channels/permissions_set.rs
+++ b/crates/delta/src/routes/channels/permissions_set.rs
@@ -1,23 +1,10 @@
 use rocket::serde::json::Json;
-use serde::Deserialize;
 
 use revolt_quark::{
+    delta::DataPermissionsField,
     models::{Channel, User},
     perms, Db, Error, Override, Permission, Ref, Result,
 };
-
-/// # Permission Value
-#[derive(Deserialize, JsonSchema)]
-pub struct Data {
-    /// Allow / deny values to set for this role
-    permissions: Override,
-}
-
-/// # Set Role Permission
-///
-/// Sets permissions for the specified role in this channel.
-///
-/// Channel must be a `TextChannel` or `VoiceChannel`.
 #[openapi(tag = "Channel Permissions")]
 #[put("/<target>/permissions/<role_id>", data = "<data>", rank = 2)]
 pub async fn req(
@@ -25,7 +12,7 @@ pub async fn req(
     user: User,
     target: Ref,
     role_id: String,
-    data: Json<Data>,
+    data: Json<DataPermissionsField>,
 ) -> Result<Json<Channel>> {
     let mut channel = target.as_channel(db).await?;
     let mut permissions = perms(&user).channel(&channel);

--- a/crates/delta/src/routes/channels/permissions_set_default.rs
+++ b/crates/delta/src/routes/channels/permissions_set_default.rs
@@ -1,25 +1,9 @@
-use rocket::serde::json::Json;
-use serde::Deserialize;
-
 use revolt_quark::{
+    delta::DataPermissionPoly,
     models::{channel::PartialChannel, Channel, User},
-    perms, Db, Error, Override, Permission, Ref, Result,
+    perms, Db, Error, Permission, Ref, Result,
 };
-
-/// # Permission Value
-#[derive(Deserialize, JsonSchema)]
-#[serde(untagged)]
-pub enum DataDefaultChannelPermissions {
-    Value {
-        /// Permission values to set for members in a `Group`
-        permissions: u64,
-    },
-    Field {
-        /// Allow / deny values to set for members in this `TextChannel` or `VoiceChannel`
-        permissions: Override,
-    },
-}
-
+use rocket::serde::json::Json;
 /// # Set Default Permission
 ///
 /// Sets permissions for the default role in this channel.
@@ -31,7 +15,7 @@ pub async fn req(
     db: &Db,
     user: User,
     target: Ref,
-    data: Json<DataDefaultChannelPermissions>,
+    data: Json<DataPermissionPoly>,
 ) -> Result<Json<Channel>> {
     let data = data.into_inner();
 
@@ -43,7 +27,7 @@ pub async fn req(
 
     match &channel {
         Channel::Group { .. } => {
-            if let DataDefaultChannelPermissions::Value { permissions } = data {
+            if let DataPermissionPoly::Value { permissions } = data {
                 channel
                     .update(
                         db,
@@ -66,7 +50,7 @@ pub async fn req(
             default_permissions,
             ..
         } => {
-            if let DataDefaultChannelPermissions::Field { permissions } = data {
+            if let DataPermissionPoly::Field { permissions } = data {
                 perm.throw_permission_override(
                     db,
                     default_permissions.map(|x| x.into()),

--- a/crates/delta/src/routes/servers/permissions_set.rs
+++ b/crates/delta/src/routes/servers/permissions_set.rs
@@ -1,17 +1,10 @@
 use rocket::serde::json::Json;
-use serde::Deserialize;
 
 use revolt_quark::{
+    delta::DataPermissionsField,
     models::{Server, User},
     perms, Db, Error, Override, Permission, Ref, Result,
 };
-
-/// # Permission Value
-#[derive(Deserialize, JsonSchema)]
-pub struct DataSetServerRolePermission {
-    /// Allow / deny values for the role in this server.
-    permissions: Override,
-}
 
 /// # Set Role Permission
 ///
@@ -23,7 +16,7 @@ pub async fn req(
     user: User,
     target: Ref,
     role_id: String,
-    data: Json<DataSetServerRolePermission>,
+    data: Json<DataPermissionsField>,
 ) -> Result<Json<Server>> {
     let data = data.into_inner();
 

--- a/crates/delta/src/routes/servers/permissions_set_default.rs
+++ b/crates/delta/src/routes/servers/permissions_set_default.rs
@@ -1,17 +1,9 @@
-use rocket::serde::json::Json;
-use serde::Deserialize;
-
 use revolt_quark::{
+    delta::DataPermissionsValue,
     models::{server::PartialServer, Server, User},
     perms, Db, Permission, Ref, Result,
 };
-
-/// # Permission Value
-#[derive(Deserialize, JsonSchema)]
-pub struct DataSetServerDefaultPermission {
-    /// Default member permission value
-    permissions: u64,
-}
+use rocket::serde::json::Json;
 
 /// # Set Default Permission
 ///
@@ -22,7 +14,7 @@ pub async fn req(
     db: &Db,
     user: User,
     target: Ref,
-    data: Json<DataSetServerDefaultPermission>,
+    data: Json<DataPermissionsValue>,
 ) -> Result<Json<Server>> {
     let data = data.into_inner();
 

--- a/crates/quark/src/permissions/defn/delta.rs
+++ b/crates/quark/src/permissions/defn/delta.rs
@@ -1,0 +1,28 @@
+use crate::Override;
+use serde::{Deserialize, Serialize};
+
+/// Data permissions Field - contains both allow and deny
+#[derive(Deserialize, Serialize, JsonSchema, Debug, Clone, Copy)]
+pub struct DataPermissionsField {
+    pub permissions: Override,
+}
+
+/// Data permissions Value - contains allow
+#[derive(Deserialize, Serialize, JsonSchema, Debug, Clone, Copy)]
+pub struct DataPermissionsValue {
+    pub permissions: u64,
+}
+
+/// Data permissions Poly - can contain either Value or Field
+#[derive(Deserialize, Serialize, JsonSchema, Debug, Clone, Copy)]
+#[serde(untagged)]
+pub enum DataPermissionPoly {
+    Value {
+        /// Permission values to set for members in a `Group`
+        permissions: u64,
+    },
+    Field {
+        /// Allow / deny values to set for members in this `TextChannel` or `VoiceChannel`
+        permissions: Override,
+    },
+}

--- a/crates/quark/src/permissions/defn/mod.rs
+++ b/crates/quark/src/permissions/defn/mod.rs
@@ -1,3 +1,4 @@
+pub mod delta;
 mod permission;
 mod user;
 
@@ -12,7 +13,7 @@ use serde::{Deserialize, Serialize};
 pub struct PermissionValue(u64);
 
 /// Representation of a single permission override
-#[derive(Deserialize, JsonSchema, Debug, Clone, Copy)]
+#[derive(Deserialize, Serialize, JsonSchema, Debug, Clone, Copy)]
 pub struct Override {
     /// Allow bit flags
     allow: u64,


### PR DESCRIPTION
## Please make sure to check the following tasks before opening and submitting a PR

* [x] I understand and have followed the [contribution guide](https://github.com/revoltchat/revolt/discussions/282)
* [x] I have tested my changes locally and they are working as intended
* [x] These changes do not have any notable side effects on other Revolt projects


This moves some of the permission structures to Quark, as well as removing inconsistently named double-ups of permission data structures 