### PR TITLE
fix:(bonfire) Ensure cache is populated before calculating permissions

### DIFF
--- a/crates/quark/src/events/impl.rs
+++ b/crates/quark/src/events/impl.rs
@@ -353,7 +353,7 @@ impl State {
                 let could_view: bool = if let Some(channel) = self.cache.channels.get(id) {
                     self.cache.can_view_channel(db, channel).await
                 } else {
-                    true
+                    false
                 };
 
                 if let Some(channel) = self.cache.channels.get_mut(id) {
@@ -362,6 +362,12 @@ impl State {
                     }
 
                     channel.apply_options(data.clone());
+                }
+
+                if !self.cache.channels.contains_key(id) {
+                    if let Ok(channel) = db.fetch_channel(id).await {
+                        self.cache.channels.insert(id.clone(), channel);
+                    }
                 }
 
                 if let Some(channel) = self.cache.channels.get(id) {

--- a/crates/quark/src/impl/dummy/servers/server_member.rs
+++ b/crates/quark/src/impl/dummy/servers/server_member.rs
@@ -3,22 +3,10 @@ use crate::{AbstractServerMember, Result};
 
 use super::super::DummyDb;
 
-use iso8601_timestamp::Timestamp;
-
 #[async_trait]
 impl AbstractServerMember for DummyDb {
     async fn fetch_member(&self, server: &str, user: &str) -> Result<Member> {
-        Ok(Member {
-            id: MemberCompositeKey {
-                server: server.into(),
-                user: user.into(),
-            },
-            joined_at: Timestamp::now_utc(),
-            nickname: None,
-            avatar: None,
-            roles: vec![],
-            timeout: None,
-        })
+        Ok(Member::new(server.into(), user.into()))
     }
 
     async fn insert_member(&self, member: &Member) -> Result<()> {

--- a/crates/quark/src/impl/generic/servers/server.rs
+++ b/crates/quark/src/impl/generic/servers/server.rs
@@ -1,6 +1,5 @@
 use std::collections::HashSet;
 
-use iso8601_timestamp::Timestamp;
 use ulid::Ulid;
 
 use crate::{
@@ -186,18 +185,7 @@ impl Server {
             return Err(Error::Banned);
         }
 
-        let member = Member {
-            id: MemberCompositeKey {
-                server: self.id.clone(),
-                user: user.id.clone(),
-            },
-            joined_at: Timestamp::now_utc(),
-            nickname: None,
-            avatar: None,
-            roles: vec![],
-            timeout: None,
-        };
-
+        let member = Member::new(self.id.clone(), user.id.clone());
         db.insert_member(&member).await?;
 
         let should_fetch = channels.is_none();

--- a/crates/quark/src/impl/generic/servers/server_member.rs
+++ b/crates/quark/src/impl/generic/servers/server_member.rs
@@ -3,13 +3,27 @@ use iso8601_timestamp::Timestamp;
 use crate::{
     events::client::EventV1,
     models::{
-        server_member::{FieldsMember, PartialMember},
+        server_member::{FieldsMember, MemberCompositeKey, PartialMember},
         Member, Server,
     },
     Database, Result,
 };
 
 impl Member {
+    pub fn new(server_id: String, user_id: String) -> Self {
+        Self {
+            id: MemberCompositeKey {
+                server: server_id,
+                user: user_id,
+            },
+            joined_at: Timestamp::now_utc(),
+            nickname: None,
+            avatar: None,
+            roles: vec![],
+            timeout: None,
+        }
+    }
+
     /// Update member data
     pub async fn update<'a>(
         &mut self,


### PR DESCRIPTION
* [X] I understand and have followed the [contribution guide](https://github.com/revoltchat/revolt/discussions/282)
* [X] I have tested my changes locally and they are working as intended
* [X] These changes do not have any notable side effects on other Revolt projects

Fixes clients not receiving ChannelCreate event if channel was not already present in cache.

Insert members and servers into cache before filtering channels to prevent fetching them for every channel.
Closes #231 