### PR TITLE
fix: set relationship for users in BulkMessageResponse

### DIFF
--- a/crates/delta/src/routes/channels/message_query.rs
+++ b/crates/delta/src/routes/channels/message_query.rs
@@ -91,7 +91,7 @@ pub async fn req(
         })
         .await?;
 
-    BulkMessageResponse::transform(db, Some(&channel), messages, include_users)
+    BulkMessageResponse::transform(db, Some(&channel), messages, &user, include_users)
         .await
         .map(Json)
 }

--- a/crates/delta/src/routes/channels/message_search.rs
+++ b/crates/delta/src/routes/channels/message_search.rs
@@ -90,7 +90,7 @@ pub async fn req(
         })
         .await?;
 
-    BulkMessageResponse::transform(db, Some(&channel), messages, include_users)
+    BulkMessageResponse::transform(db, Some(&channel), messages, &user, include_users)
         .await
         .map(Json)
 }

--- a/crates/quark/src/impl/generic/channels/message.rs
+++ b/crates/quark/src/impl/generic/channels/message.rs
@@ -382,11 +382,16 @@ impl BulkMessageResponse {
         db: &Database,
         channel: Option<&Channel>,
         messages: Vec<Message>,
+        user: &User,
         include_users: Option<bool>,
     ) -> Result<BulkMessageResponse> {
         if let Some(true) = include_users {
             let user_ids = messages.get_user_ids();
-            let users = User::fetch_foreign_users(db, &user_ids).await?;
+            let users = User::fetch_foreign_users(db, &user_ids)
+                .await?
+                .into_iter()
+                .map(|x| x.with_relationship(user))
+                .collect();
 
             Ok(match channel {
                 Some(Channel::TextChannel { server, .. })


### PR DESCRIPTION
* [X] I understand and have followed the [contribution guide](https://github.com/revoltchat/revolt/discussions/282)
* [X] I have tested my changes locally and they are working as intended
* [X] These changes do not have any notable side effects on other Revolt projects

Set the relationship field on users when included in a BulkMessageResponse.