### PR TITLE
fix: allow reacting with existing emojis when at limit

### DIFF
--- a/crates/quark/src/impl/generic/channels/message.rs
+++ b/crates/quark/src/impl/generic/channels/message.rs
@@ -192,7 +192,7 @@ impl Message {
     /// Add a reaction to a message
     pub async fn add_reaction(&self, db: &Database, user: &User, emoji: &str) -> Result<()> {
         // Check how many reactions are already on the message
-        if self.reactions.len() >= 20 {
+        if self.reactions.len() >= 20 && !self.reactions.contains_key(emoji) {
             return Err(Error::InvalidOperation);
         }
 


### PR DESCRIPTION
* [X] I understand and have followed the [contribution guide](https://github.com/revoltchat/revolt/discussions/282)
* [X] I have tested my changes locally and they are working as intended
* [X] These changes do not have any notable side effects on other Revolt projects

Fixes not being able to react with an existing emoji on a message if it was at the unique emoji limit.