### PR TITLE
replace runtime image to distrolles run as noroot

### DIFF
--- a/crates/bonfire/Dockerfile
+++ b/crates/bonfire/Dockerfile
@@ -2,10 +2,14 @@
 FROM ghcr.io/revoltchat/base:latest AS builder
 
 # Bundle Stage
-FROM debian:bullseye-slim
-RUN apt-get update && \
-    apt-get install -y ca-certificates && \
-    apt-get clean
+FROM gcr.io/distroless/cc:nonroot
+
+# copy our compiled binary
 COPY --from=builder /home/rust/src/target/release/revolt-bonfire ./
 EXPOSE 9000
+
+# run as non-privileged user
+USER nonroot
+
+# command of container
 CMD ["./revolt-bonfire"]

--- a/crates/delta/Dockerfile
+++ b/crates/delta/Dockerfile
@@ -2,13 +2,17 @@
 FROM ghcr.io/revoltchat/base:latest AS builder
 
 # Bundle Stage
-FROM debian:bullseye-slim
-RUN apt-get update && \
-    apt-get install -y ca-certificates && \
-    apt-get clean
+FROM gcr.io/distroless/cc:nonroot
+
+# copy our compiled binary
 COPY --from=builder /home/rust/src/target/release/revolt-delta ./
 
 EXPOSE 8000
 ENV ROCKET_ADDRESS 0.0.0.0
 ENV ROCKET_PORT 8000
+
+# run as non-privileged user
+USER nonroot
+
+# command of container
 CMD ["./revolt-delta"]


### PR DESCRIPTION
I've implemented distrolles to remove CVEs from libraries not used in the project, you never know when they might haunt you hahaha

https://github.com/revoltchat/backend/issues/298

https://github.com/revoltchat/backend/security/advisories/GHSA-m2p9-rmqf-455p

### Please make sure to check the following tasks before opening and submitting a PR

- [X] I understand and have followed the https://github.com/revoltchat/revolt/discussions/282
- [X] I have tested my changes locally and they are working as intended
- [X] These changes do not have any notable side effects on other Revolt projects