### PR TITLE
docs(readme): added note for Windows developer builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ Before getting started, you'll want to install:
 > A **default.nix** is available for Nix users!
 > Just run `nix-shell` and continue.
 
+> Windows users must perform the steps below within **Git Bash** and not Powershell or Command Prompt. Otherwise, you will likely encounter build errors because Windows does not recognize Linux commands like 'cp'.
+
 Now you can clone and build the project:
 
 ```bash


### PR DESCRIPTION
Informs Windows developers to use Git Bash when following the steps in the Development Guide for a successful revolt-delta build (among other things).

see issue #339

## Please make sure to check the following tasks before opening and submitting a PR

- [x] I understand and have followed the [contribution guide](https://github.com/revoltchat/.github/blob/master/.github/CONTRIBUTING.md)
- [x] I have tested my changes locally and they are working as intended
