### PR TITLE
perf(lto): Enable link-time optimization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ target
 
 .vercel
 .DS_Store
+
+.idea

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,3 +14,6 @@ redis22 = { package = "redis", version = "0.22.3", git = "https://github.com/rev
 redis23 = { package = "redis", version = "0.23.1", git = "https://github.com/revoltchat/redis-rs", rev = "f8ca28ab85da59d2ccde526b4d2fb390eff5a5f9" }
 # authifier = { package = "authifier", version = "1.0.8", path = "../authifier/crates/authifier" }
 # rocket_authifier = { package = "rocket_authifier", version = "1.0.8", path = "../authifier/crates/rocket_authifier" }
+
+[profile.release]
+lto = true


### PR DESCRIPTION
This change will allow to do better PGO, as well as reduces binary size quite a bit. e.g. bonfire - 30m vs 23m

resolves #369 

## Please make sure to check the following tasks before opening and submitting a PR

- [x] I understand and have followed the [contribution guide](https://github.com/revoltchat/.github/blob/master/.github/CONTRIBUTING.md)
- [x] I have tested my changes locally and they are working as intended
