### PR TITLE
feat: allow to set an icon when creating a group chat

### DIFF
--- a/crates/core/database/src/models/channels/model.rs
+++ b/crates/core/database/src/models/channels/model.rs
@@ -269,16 +269,24 @@ impl Channel {
             }));
         }
 
+        let id = ulid::Ulid::new().to_string();
+
+        let icon = if let Some(icon_id) = data.icon {
+            Some(File::use_channel_icon(db, &icon_id, &id, &owner_id).await?)
+        } else {
+            None
+        };
+
         let recipients = data.users.into_iter().collect::<Vec<String>>();
         let channel = Channel::Group {
-            id: ulid::Ulid::new().to_string(),
+            id,
 
             name: data.name,
             owner: owner_id,
             description: data.description,
             recipients: recipients.clone(),
 
-            icon: None,
+            icon,
             last_message_id: None,
 
             permissions: None,


### PR DESCRIPTION
This PR adds the ability to change the group icon when creating a group chat.

The frontend would have to set the "icon" field when creating a new group to set the icon. Where "icon" contains the id of a previously uploaded icon. If you don't want to set an icon, do not add the field to the request.

Fixes #220