### PR TITLE
fix: allow message pinning and unpinning for DM-like channels

### DIFF
--- a/crates/delta/src/routes/channels/message_pin.rs
+++ b/crates/delta/src/routes/channels/message_pin.rs
@@ -19,7 +19,7 @@ pub async fn message_pin(
 ) -> Result<EmptyResponse> {
     let channel = target.as_channel(db).await?;
 
-    if !matches!(channel, Channel::DirectMessage { .. } | Channel::Group { .. } | Channel::SavedMessages { .. }) {
+    if !matches!(channel, Channel::DirectMessage { .. }) {
         let mut query = DatabasePermissionQuery::new(db, &user).channel(&channel);
         calculate_channel_permissions(&mut query)
             .await

--- a/crates/delta/src/routes/channels/message_unpin.rs
+++ b/crates/delta/src/routes/channels/message_unpin.rs
@@ -19,7 +19,7 @@ pub async fn message_unpin(
 ) -> Result<EmptyResponse> {
     let channel = target.as_channel(db).await?;
 
-    if !matches!(channel, Channel::DirectMessage { .. } | Channel::Group { .. } | Channel::SavedMessages { .. }) {
+    if !matches!(channel, Channel::DirectMessage { .. }) {
         let mut query = DatabasePermissionQuery::new(db, &user).channel(&channel);
         calculate_channel_permissions(&mut query)
             .await

--- a/crates/delta/src/routes/channels/message_unpin.rs
+++ b/crates/delta/src/routes/channels/message_unpin.rs
@@ -1,7 +1,4 @@
-use revolt_database::{
-    util::{permissions::DatabasePermissionQuery, reference::Reference},
-    Database, FieldsMessage, PartialMessage, SystemMessage, User, AMQP,
-};
+use revolt_database::{util::{permissions::DatabasePermissionQuery, reference::Reference}, Channel, Database, FieldsMessage, PartialMessage, SystemMessage, User, AMQP};
 use revolt_models::v0::MessageAuthor;
 use revolt_permissions::{calculate_channel_permissions, ChannelPermission};
 use revolt_result::{create_error, Result};
@@ -22,10 +19,12 @@ pub async fn message_unpin(
 ) -> Result<EmptyResponse> {
     let channel = target.as_channel(db).await?;
 
-    let mut query = DatabasePermissionQuery::new(db, &user).channel(&channel);
-    calculate_channel_permissions(&mut query)
-        .await
-        .throw_if_lacking_channel_permission(ChannelPermission::ManageMessages)?;
+    if !matches!(channel, Channel::DirectMessage { .. } | Channel::Group { .. } | Channel::SavedMessages { .. }) {
+        let mut query = DatabasePermissionQuery::new(db, &user).channel(&channel);
+        calculate_channel_permissions(&mut query)
+            .await
+            .throw_if_lacking_channel_permission(ChannelPermission::ManageMessages)?;
+    }
 
     let mut message = msg.as_message_in_channel(db, channel.id()).await?;
 


### PR DESCRIPTION
- [x] I understand and have followed the [contribution guide](https://github.com/revoltchat/.github/blob/master/.github/CONTRIBUTING.md)
- [x] I have tested my changes locally and they are working as intended *(this took me over an hour btw because local.revolt.chat was being weird)*

# Pinning
## Saved Notes
![image](https://github.com/user-attachments/assets/57a70862-f9fb-453d-aa9b-21a73255f71f)
### Search Result
![image](https://github.com/user-attachments/assets/01be1302-d3f2-47ba-90cb-ea1f36018001)

## DM
![image](https://github.com/user-attachments/assets/b9780a15-4c6c-4bc4-af29-9aa5d5fd99ea)
### Search Result
![image](https://github.com/user-attachments/assets/a1670706-cb22-4504-aebe-a33e30ad400e)

## Group Chat
![image](https://github.com/user-attachments/assets/524389ef-979c-4fb6-986e-38ef874a5e91)
### Search Result
![image](https://github.com/user-attachments/assets/3b4f29bf-29bf-4bc3-83e3-2f640eba4ea1)

# Channel (no perms)
![image](https://github.com/user-attachments/assets/46b0f4d8-16cc-4f38-9f70-0ece7fa99f47)
I don't think I need to provide a search result for this, lol.



# Unpinning
## Saved Notes
![image](https://github.com/user-attachments/assets/6be95d65-1d54-4931-8be8-f309d3f226c6)
### Search Result
![image](https://github.com/user-attachments/assets/171bf6bd-f19e-4dab-9f27-f93df23b197c)

Not going to do the others because you should get the idea by now.