### PR TITLE
feat: role icons

### DIFF
--- a/crates/core/database/src/models/files/model.rs
+++ b/crates/core/database/src/models/files/model.rs
@@ -70,6 +70,7 @@ auto_derived!(
         LegacyGroupIcon,
         ChannelIcon,
         ServerIcon,
+        RoleIcon,
     }
 
     /// Information about what the file was used for
@@ -200,6 +201,25 @@ impl File {
             uploader_id.to_owned(),
         )
         .await
+    }
+
+    /// Use a file for a role icon
+    pub async fn use_role_icon(
+        db: &Database,
+        id: &str,
+        parent: &str,
+        uploader_id: &str,
+    ) -> Result<File> {
+        db.find_and_use_attachment(
+            id,
+            "icons",
+            FileUsedFor {
+                id: parent.to_owned(),
+                object_type: FileUsedForType::RoleIcon,
+            },
+            uploader_id.to_owned(),
+        )
+            .await
     }
 
     /// Use a file for a server banner

--- a/crates/core/database/src/models/servers/model.rs
+++ b/crates/core/database/src/models/servers/model.rs
@@ -70,6 +70,10 @@ auto_derived_partial!(
     pub struct Role {
         /// Role name
         pub name: String,
+        /// Icon attachment
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub icon: Option<File>,
+        ///
         /// Permissions available to this role
         pub permissions: OverrideField,
         /// Colour used for this role
@@ -123,9 +127,10 @@ auto_derived!(
         Banner,
     }
 
-    /// Optional fields on server object
+    /// Optional fields on role object
     pub enum FieldsRole {
         Colour,
+        Icon,
     }
 );
 
@@ -260,6 +265,7 @@ impl Role {
     pub fn into_optional(self) -> PartialRole {
         PartialRole {
             name: Some(self.name),
+            icon: self.icon,
             permissions: Some(self.permissions),
             colour: self.colour,
             hoist: Some(self.hoist),
@@ -318,6 +324,7 @@ impl Role {
     pub fn remove_field(&mut self, field: &FieldsRole) {
         match field {
             FieldsRole::Colour => self.colour = None,
+            FieldsRole::Icon => self.icon = None,
         }
     }
 

--- a/crates/core/database/src/models/servers/ops/mongodb.rs
+++ b/crates/core/database/src/models/servers/ops/mongodb.rs
@@ -145,6 +145,10 @@ impl AbstractServers for MongoDb {
             .await
             .map_err(|_| create_database_error!("update_one", "channels"))?;
 
+        self.delete_many_attachments(doc! {
+            "used_for.id": &role_id
+        }).await?;
+
         self.col::<Document>("servers")
             .update_one(
                 doc! {
@@ -179,6 +183,7 @@ impl IntoDocumentPath for FieldsRole {
     fn as_path(&self) -> Option<&'static str> {
         Some(match self {
             FieldsRole::Colour => "colour",
+            FieldsRole::Icon => "icon",
         })
     }
 }

--- a/crates/core/database/src/util/bridge/v0.rs
+++ b/crates/core/database/src/util/bridge/v0.rs
@@ -1,7 +1,7 @@
 use revolt_models::v0::*;
 use revolt_permissions::{calculate_user_permissions, UserPermission};
 
-use crate::{util::permissions::DatabasePermissionQuery, Database, FileUsedFor};
+use crate::{util::permissions::DatabasePermissionQuery, Database};
 
 impl crate::Bot {
     pub fn into_public_bot(self, user: crate::User) -> PublicBot {
@@ -897,6 +897,7 @@ impl From<crate::Role> for Role {
     fn from(value: crate::Role) -> Self {
         Role {
             name: value.name,
+            icon: value.icon.map(|f| f.into()),
             permissions: value.permissions,
             colour: value.colour,
             hoist: value.hoist,
@@ -909,6 +910,7 @@ impl From<Role> for crate::Role {
     fn from(value: Role) -> crate::Role {
         crate::Role {
             name: value.name,
+            icon: value.icon.map(|f| f.into()),
             permissions: value.permissions,
             colour: value.colour,
             hoist: value.hoist,
@@ -921,6 +923,7 @@ impl From<crate::PartialRole> for PartialRole {
     fn from(value: crate::PartialRole) -> Self {
         PartialRole {
             name: value.name,
+            icon: value.icon.map(|f| f.into()),
             permissions: value.permissions,
             colour: value.colour,
             hoist: value.hoist,
@@ -933,6 +936,7 @@ impl From<PartialRole> for crate::PartialRole {
     fn from(value: PartialRole) -> crate::PartialRole {
         crate::PartialRole {
             name: value.name,
+            icon: value.icon.map(|f| f.into()),
             permissions: value.permissions,
             colour: value.colour,
             hoist: value.hoist,
@@ -945,6 +949,7 @@ impl From<crate::FieldsRole> for FieldsRole {
     fn from(value: crate::FieldsRole) -> Self {
         match value {
             crate::FieldsRole::Colour => FieldsRole::Colour,
+            crate::FieldsRole::Icon => FieldsRole::Icon,
         }
     }
 }
@@ -953,6 +958,7 @@ impl From<FieldsRole> for crate::FieldsRole {
     fn from(value: FieldsRole) -> Self {
         match value {
             FieldsRole::Colour => crate::FieldsRole::Colour,
+            FieldsRole::Icon => crate::FieldsRole::Icon,
         }
     }
 }

--- a/crates/core/models/src/v0/servers.rs
+++ b/crates/core/models/src/v0/servers.rs
@@ -121,7 +121,7 @@ auto_derived!(
         Banner,
     }
 
-    /// Optional fields on server object
+    /// Optional fields on role object
     pub enum FieldsRole {
         Colour,
         Icon,

--- a/crates/core/models/src/v0/servers.rs
+++ b/crates/core/models/src/v0/servers.rs
@@ -87,6 +87,10 @@ auto_derived_partial!(
     pub struct Role {
         /// Role name
         pub name: String,
+        /// Icon attachment
+        #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
+        pub icon: Option<File>,
+
         /// Permissions available to this role
         pub permissions: OverrideField,
         /// Colour used for this role
@@ -120,6 +124,7 @@ auto_derived!(
     /// Optional fields on server object
     pub enum FieldsRole {
         Colour,
+        Icon,
     }
 
     /// Channel category
@@ -257,6 +262,9 @@ auto_derived!(
         /// Role name
         #[cfg_attr(feature = "validator", validate(length(min = 1, max = 32)))]
         pub name: Option<String>,
+        /// Attachment Id for icon
+        pub icon: Option<String>,
+
         /// Role colour
         #[cfg_attr(
             feature = "validator",
@@ -269,6 +277,7 @@ auto_derived!(
         ///
         /// Smaller values take priority.
         pub rank: Option<i64>,
+
         /// Fields to remove from role object
         #[cfg_attr(feature = "validator", validate(length(min = 1)))]
         pub remove: Option<Vec<FieldsRole>>,

--- a/crates/delta/src/routes/channels/message_send.rs
+++ b/crates/delta/src/routes/channels/message_send.rs
@@ -158,6 +158,7 @@ mod test {
         let role = Role {
             name: "Show Hidden Channel".to_string(),
             permissions: OverrideField { a: 0, d: 0 },
+            icon: None,
             colour: None,
             hoist: false,
             rank: 5,

--- a/crates/delta/src/routes/servers/roles_create.rs
+++ b/crates/delta/src/routes/servers/roles_create.rs
@@ -53,6 +53,7 @@ pub async fn create(
 
     let role = Role {
         name: data.name,
+        icon: None,
         rank,
         colour: None,
         hoist: false,

--- a/crates/delta/src/routes/servers/roles_create.rs
+++ b/crates/delta/src/routes/servers/roles_create.rs
@@ -53,8 +53,8 @@ pub async fn create(
 
     let role = Role {
         name: data.name,
-        icon: None,
         rank,
+        icon: None,
         colour: None,
         hoist: false,
         permissions: Default::default(),


### PR DESCRIPTION
- [x] I understand and have followed the [contribution guide](https://github.com/revoltchat/.github/blob/master/.github/CONTRIBUTING.md)
- [x] I have tested my changes locally and they are working as intended

# ⚠ Breaks: Saving roles in Revite client
This breaks saving roles, that have icons, on the Revite client. This is because it passes through the whole `icon` file object thing in the PATCH request, instead of omitting it.
## What breaks?
When saving, it sends the full icon object (when it can just be completely omitted instead). Here's what I mean:
![image](https://github.com/user-attachments/assets/0a9a4622-1d74-4937-a679-ad6a62b9affc)

[View RFC][rfc]

[rfc]: https://github.com/revoltchat/rfcs/pull/15