### PR TITLE
Allow bots to manage emojis

### DIFF
--- a/crates/delta/src/routes/customisation/emoji_create.rs
+++ b/crates/delta/src/routes/customisation/emoji_create.rs
@@ -27,11 +27,6 @@ pub async fn create_emoji(
         })
     })?;
 
-    // Bots cannot manage emojis
-    if user.bot.is_some() {
-        return Err(create_error!(IsBot));
-    }
-
     // Validate we have permission to write into parent
     match &data.parent {
         v0::EmojiParent::Server { id } => {

--- a/crates/delta/src/routes/customisation/emoji_delete.rs
+++ b/crates/delta/src/routes/customisation/emoji_delete.rs
@@ -18,10 +18,6 @@ pub async fn delete_emoji(
     user: User,
     emoji_id: Reference,
 ) -> Result<EmptyResponse> {
-    // Bots cannot manage emoji
-    if user.bot.is_some() {
-        return Err(create_error!(IsBot));
-    }
 
     // Fetch the emoji
     let emoji = emoji_id.as_emoji(db).await?;


### PR DESCRIPTION
- [x] I understand and have followed the [contribution guide](https://github.com/revoltchat/.github/blob/master/.github/CONTRIBUTING.md)
- [ ] I have tested my changes locally and they are working as intended

This is just a simple change to allow bots to create and delete emojis.