### PR TITLE
docs: correct Revolt config override filename

### DIFF
--- a/Revolt.toml
+++ b/Revolt.toml
@@ -1,5 +1,5 @@
 # ⚠️ This configuration is intended for development environment.
-# If you'd like to override anything, create a Revolt.override.toml
+# If you'd like to override anything, create a Revolt.overrides.toml
 
 [database]
 # MongoDB connection URL


### PR DESCRIPTION
Tested myself `Revolt.override.toml` doesn't work and `Revolt.overrides.toml` does indeed work and source code also confirms it: https://github.com/revoltchat/backend/blob/a1b0e4767ad88bb3113f3bdc15cb16b224b64da7/crates/core/config/src/lib.rs#L57

## Please make sure to check the following tasks before opening and submitting a PR

- [x] I understand and have followed the [contribution guide](https://github.com/revoltchat/.github/blob/master/.github/CONTRIBUTING.md)
- [x] I have tested my changes locally and they are working as intended