### PR TITLE
chore: use mc alias set instead of mc config

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -34,7 +34,7 @@ services:
       - minio
     entrypoint: >
       /bin/sh -c "while ! /usr/bin/mc ready minio; do
-        /usr/bin/mc config host add minio http://minio:9000 minioautumn minioautumn;
+        /usr/bin/mc alias set minio http://minio:9000 minioautumn minioautumn;
         echo 'Waiting minio...' && sleep 1;
       done; /usr/bin/mc mb minio/revolt-uploads; exit 0;"
 


### PR DESCRIPTION
While trying to start the backend locally for development i noticed that the createbuckets-container was throwing the following error:

```
createbuckets-1  | mc: <ERROR> `config` is not a recognized command. Get help using `--help` flag. 
createbuckets-1  | Waiting minio...
createbuckets-1  | mc: <ERROR> Couldn't construct anonymous client for `minio`. No valid configuration found for 'minio' host alias.
```

According to https://github.com/minio/mc/issues/5206 the `mc config` command has long been deprecated and recently been removed. This PR switches it to the `mc alias`.

## Please make sure to check the following tasks before opening and submitting a PR

- [x] I understand and have followed the [contribution guide](https://github.com/revoltchat/.github/blob/master/.github/CONTRIBUTING.md)
- [x] I have tested my changes locally and they are working as intended
