### PR TITLE
feat: automatically sanitise usernames on create/update 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2003,9 +2003,13 @@ dependencies = [
 
 [[package]]
 name = "decancer"
-version = "1.6.5"
+version = "3.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "080b09f6adad25c23d8c47c54e52e59b0dc09d079c4b23e0f147dac440359d0d"
+checksum = "a9244323129647178bf41ac861a2cdb9d9c81b9b09d3d0d1de9cd302b33b8a1d"
+dependencies = [
+ "lazy_static",
+ "regex",
+]
 
 [[package]]
 name = "der"
@@ -2384,7 +2388,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cea14ef9355e3beab063703aa9dab15afd25f0667c341310c1e5274bb1d0da18"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3806,7 +3810,7 @@ checksum = "e04d7f318608d35d4b61ddd75cbdaee86b023ebe2bd5a66ee0915f0bf93095a9"
 dependencies = [
  "hermit-abi 0.5.1",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6902,7 +6906,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6915,7 +6919,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.9.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -8039,7 +8043,7 @@ dependencies = [
  "getrandom 0.3.3",
  "once_cell",
  "rustix 1.0.7",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -9236,7 +9240,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/crates/core/database/Cargo.toml
+++ b/crates/core/database/Cargo.toml
@@ -47,7 +47,7 @@ nanoid = "0.4.0"
 base64 = "0.21.3"
 once_cell = "1.17"
 indexmap = "1.9.1"
-decancer = "1.6.2"
+decancer = "3.3.3"
 deadqueue = "0.2.4"
 linkify = { optional = true, version = "0.8.1" }
 url-escape = { optional = true, version = "0.1.1" }


### PR DESCRIPTION
Fixes #257 

This PR contains the following:
- Usernames are now sanitized on create/username update and prohibited words/chars are removed from the username
- If prohibited words/chars were sanitized the `display_name` is set to the username originally provided by the user
- If the sanitised username is shorter than the min required length the username will be padded with `_`
- Tests for validation and sanitisation of usernames
- The decancer crate is updated from `1.6.2` to `3.3.3` to facilitate preserving capitalisation on sanitisation

In the Issue it was mentioned that it might be a good idea to make the min-length of the username configurable. I left this out of this PR for now, since I don't see a nice was to do this. If you've got an Idea I'm open to suggestions.

While testing this I noticed that while creating/renaming a bot the username is updated in the UI only after reloading. I'm not quite shure as to where I'd have to fix this and would like some guidance so that I can fix that there so that the UX is consistent for normal and bot users.

## Please make sure to check the following tasks before opening and submitting a PR

- [x] I understand and have followed the [contribution guide](https://github.com/revoltchat/.github/blob/master/.github/CONTRIBUTING.md)
- [x] I have tested my changes locally and they are working as intended
