### PR TITLE
fix: remove authentication tag bytes from attachment download

### DIFF
--- a/crates/core/files/src/lib.rs
+++ b/crates/core/files/src/lib.rs
@@ -80,6 +80,9 @@ pub async fn fetch_from_s3(bucket_id: &str, path: &str, nonce: &str) -> Result<V
         .decrypt_in_place(nonce, b"", &mut buf)
         .map_err(|_| create_error!(InternalError))?;
 
+    // Remove the authentication tag bytes that were added during encryption
+    buf.truncate(buf.len() - AUTHENTICATION_TAG_SIZE_BYTES);
+
     Ok(buf)
 }
 


### PR DESCRIPTION
Fixes #416 

This PR fixes an issue with S3 auth in attachments. Truncate authentication bytes when downloading attachments, so that when the file is fetched and decrypted from Revolt, it matches the original file exactly without being padded with 16 null bytes.

## Please make sure to check the following tasks before opening and submitting a PR

- [x] I understand and have followed the [contribution guide](https://github.com/revoltchat/.github/blob/master/.github/CONTRIBUTING.md)
- [x] I have tested my changes locally and they are working as intended
