### PR TITLE
Fix: strip decryption leftovers

### DIFF
--- a/crates/core/files/src/lib.rs
+++ b/crates/core/files/src/lib.rs
@@ -80,7 +80,8 @@ pub async fn fetch_from_s3(bucket_id: &str, path: &str, nonce: &str) -> Result<V
         .decrypt_in_place(nonce, b"", &mut buf)
         .map_err(|_| create_error!(InternalError))?;
 
-    Ok(buf)
+    // The decryption process adds 16 trailing bytes to the end of the file, so we remove them
+    Ok(buf[..buf.len() - 16])
 }
 
 /// Encrypt and upload a file to S3 (returning its nonce/IV)

--- a/crates/core/files/src/lib.rs
+++ b/crates/core/files/src/lib.rs
@@ -81,7 +81,7 @@ pub async fn fetch_from_s3(bucket_id: &str, path: &str, nonce: &str) -> Result<V
         .map_err(|_| create_error!(InternalError))?;
 
     // The decryption process adds 16 trailing bytes to the end of the file, so we remove them
-    Ok(buf[..buf.len() - 16])
+    Ok(buf[..buf.len() - 16].to_vec())
 }
 
 /// Encrypt and upload a file to S3 (returning its nonce/IV)


### PR DESCRIPTION
## Please make sure to check the following tasks before opening and submitting a PR

- [x] I understand and have followed the [contribution guide](https://github.com/revoltchat/.github/blob/master/.github/CONTRIBUTING.md)
- [x] I have tested my changes locally and they are working as intended

This PR only changes the revolt_files crate to remove the leftover bytes after a file is decrypted from S3.

Context: https://app.revolt.chat/server/01F7ZSBSFHQ8TA81725KQCSDDP/channel/01F92C5ZXBQWQ8KY7J8KY917NM/01K4JA88AJ6FCBVB6WRDYRW7HA