### PR TITLE
Fix: fixing a loophole in the API where it could be revealed to users who blocked them

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ If you have bumped the crate versions, proceed to [GitHub releases](https://gith
 First, start the required services:
 
 ```sh
-docker compose -f docker-compose.db.yml up -d
+docker compose -f compose.yml up -d
 ```
 
 Now run tests for whichever database:


### PR DESCRIPTION
## Please make sure to check the following tasks before opening and submitting a PR

- [X] I understand and have followed the [contribution guide](https://github.com/revoltchat/.github/blob/master/.github/CONTRIBUTING.md)
- [X] I have tested my changes locally and they are working as intended


I recently discovered that there are scripts that use a loophole in the backend API that allow users to determine who blocked them.  I've updated the code to return `User` as a relationship status, as to not break frontend functionality I saw on the [Android app](https://github.com/revoltchat/android/blob/7009c9083251a6853f349a61f780c078ac873b65/app/src/main/java/chat/revolt/composables/screens/settings/UserButtons.kt#L251) and the [old frontend.](https://github.com/revoltchat/android/blob/7009c9083251a6853f349a61f780c078ac873b65/app/src/main/java/chat/revolt/composables/screens/settings/UserButtons.kt#L251) while having the backend still able to correctly block blocked users from certain actions.

I also [updated the](https://github.com/alexjyong/backend/blob/6b634ef58d18b7bd9d06367e795176ea6bf5530a/crates/core/database/src/models/users/model.rs#L510) `add_friend` function to not return an error, but a 200 response so users couldn't use that as a way to see if they are blocked or not.  User bios will still be blocked, which is a way to determine if someone is blocked, but there are other reasons beyond being blocked that a bio returns None.

And of course, tests were added to confirm functionality and to ensure this didn't break anything.

My reasoning behind this change, I'm concerned current behavior could be problematic because:

- It's not unknown for people to react very poorly when they know they are blocked, and we shouldn't have loopholes that make it easy to determine.

- Easy ways to determine if you are blocked can be used by harassers and other bad-faith actors to more quickly determine when to make alt accounts to bother a user.

- Knowledge that an easy exploit to determine who blocked you may cause some users on the platform to feel unsafe. Especially people who have had a history of being targeted by hostile actors online.

- INAL, but given the increased pressure from governments, especially in the UK, where Revolt is headquartered, for maintainers of platforms to ensure safe communities, I do wonder if in a worse case scenario, someone using this exploit to engage in hostile interactions with a user could land Revolt in trouble if regulators catch wind of how it was done. Especially if the victim is a minor. INAL of course, but it seems to be a tail risk not worth having. [Article 5, paragraph 1, point (f)](https://ico.org.uk/for-organisations/uk-gdpr-guidance-and-resources/data-protection-principles/a-guide-to-the-data-protection-principles/integrity-and-confidentiality-security/) jumps out at me as a potential pain point with current functionality.

 Of course, it's almost impossible, if not completely, to  prevent someone from knowing that they are blocked, but you shouldn't be able to use the API (or scripts, web apps, etc) to determine it easily.
 
 
 ## **TL;DR of the reasoning above**
 
The API leak makes it trivial for abusers to discover who blocked them, enabling retaliation and alt-account attacks, reducing community trust in Revolt being a safe platform, and potentially (INAL), may run afoul of data privacy regulations, like the UK GDPR. While we can't completely prevent knowledge of someone being blocked, we can at least make it harder to do.


… who has blocked them. Also adding in tests to confirm functionality.

Signed-off-by: Alex Yong <alexjyong@gmail.com>