### PR TITLE
docs: Remove outdated Caution notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,9 +37,6 @@ The services and libraries that power the Revolt service.<br/>
 
 Rust 1.86.0 or higher.
 
-> [!CAUTION]
-> The events server has a significant performance regression between Rust 1.77.2 and 1.78.0 onwards, see [issue #341](https://github.com/revoltchat/backend/issues/341). This is currently solved by build time options but we are looking for a proper fix.
-
 ## Development Guide
 
 Before contributing, make yourself familiar with [our contribution guidelines](https://developers.revolt.chat/contrib.html) and the [technical documentation for this project](https://revoltchat.github.io/backend/).


### PR DESCRIPTION
#341 appears to be closed (compile time optimizations appear to have solved the problem), remove it from the README.