### PR TITLE
docs: replaced start.sh command with mise start

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ Then continue:
 docker compose up -d
 
 # run everything together
-./scripts/start.sh
+mise start
 # .. or individually
 # run the API server
 cargo run --bin revolt-delta


### PR DESCRIPTION
Small change as `./scripts/start.sh` was removed in [this commit](https://github.com/stoatchat/stoatchat/commit/2846f09c4525c3fd4fdcf9486e8bfb8c51f19827). This has been replaced with `mise start` but was missing in the documentation.