### PR TITLE
feat: load config from env vars

### DIFF
--- a/crates/core/config/src/lib.rs
+++ b/crates/core/config/src/lib.rs
@@ -1,7 +1,7 @@
 use std::{collections::HashMap, path::Path};
 
 use cached::proc_macro::cached;
-use config::{Config, File, FileFormat};
+use config::{Config, Environment, File, FileFormat};
 use futures_locks::RwLock;
 use once_cell::sync::Lazy;
 use serde::Deserialize;
@@ -108,6 +108,8 @@ static CONFIG_BUILDER: Lazy<RwLock<Config>> = Lazy::new(|| {
 
             cwd = path.parent();
         }
+
+        builder = builder.add_source(Environment::with_prefix("REVOLT").separator("__"));
 
         builder.build().unwrap()
     })


### PR DESCRIPTION
I think it'd be a really good addition to give more options for hosting, especially in regards to accessing secrets.

Env vars take precedence to file configs.

Env vars have the prefix `REVOLT`.

The separator used is `__` as `_` is already used inside the field names.

### Examples
The environment variables would look like this:
#### 1. livekit nodes
`REVOLT__API__LIVEKIT__NODES__WORLDWIDE__SECRET=abcde....`

```toml
# Revolt.toml equivalent
[api.livekit.nodes.worldwide]
secret = "verysecret"
```

### 2. smtp password

`REVOLT__API__SMTP__PASSWORD=passw0rd`

```toml
# Revolt.toml equivalent
[api.smtp]
password = "mysmtppw"
```

### 3. trust cloudflare

`REVOLT__API__SECURITY__TRUST_CLOUDFLARE=true`

```toml
# Revolt.toml equivalent
[api.security]
trust_cloudflare = false
```



