### PR TITLE
feat(gifbox): Add support for Klipy

### DIFF
--- a/crates/core/config/Revolt.toml
+++ b/crates/core/config/Revolt.toml
@@ -58,6 +58,8 @@ voso_legacy_token = ""
 trust_cloudflare = false
 # easypwned endpoint
 easypwned = ""
+# KLIPY API Key
+klipy_key = ""
 # Tenor API Key
 tenor_key = ""
 

--- a/crates/core/config/src/lib.rs
+++ b/crates/core/config/src/lib.rs
@@ -198,6 +198,7 @@ pub struct ApiSecurity {
     pub captcha: ApiSecurityCaptcha,
     pub trust_cloudflare: bool,
     pub easypwned: String,
+    pub klipy_key: String,
     pub tenor_key: String,
 }
 

--- a/crates/services/gifbox/src/main.rs
+++ b/crates/services/gifbox/src/main.rs
@@ -83,7 +83,13 @@ async fn main() -> Result<(), std::io::Error> {
         .await
         .expect("Unable to connect to database");
 
-    let tenor = tenor::Tenor::new(&config.api.security.tenor_key);
+    let use_klipy = !&config.api.security.klipy_key.is_empty();
+    let key = if use_klipy {
+        &config.api.security.klipy_key
+    } else {
+        &config.api.security.tenor_key
+    };
+    let tenor = tenor::Tenor::new(key, &use_klipy);
 
     let ratelimit_storage = ratelimiter::RatelimitStorage::new(ratelimits::GifboxRatelimits);
 


### PR DESCRIPTION
Tenor is no longer issuing new API keys and will soon shut down entirely. Klipy is a drop-in replacement API.

This commit adds support for using Klipy instead of Tenor. To use this support, simply provide a klipy_key where the tenor_key would usually go.

This change is backwards compatible. If you already have a tenor_key and do not specify a klipy_key, Tenor will continue to be used. (I can't test this because I don't have a Tenor API key, but it should work)

If you provide both a klipy_key and a tenor_key, the Klipy key takes precedence.