### PR TITLE
fix: default video resolution is a nonexistent size

### DIFF
--- a/crates/core/config/Revolt.toml
+++ b/crates/core/config/Revolt.toml
@@ -283,7 +283,7 @@ voice_quality = 16000
 # Whether the user can use video streams in voice calls
 video = true
 
-# Mamimum resolution (width, height) of video streams in voice calls
+# Maximum resolution (width, height) of video streams in voice calls
 video_resolution = [1280, 720]
 
 # Minimum and maximum aspect ratio of video streams in voice calls


### PR DESCRIPTION
fixes #588

- `main` <!-- branch-stack -->
  - \#601 :point\_left:
