### PR TITLE
fix(docs): Update GitHub links

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Rust 1.86.0 or higher.
 
 ## Development Guide
 
-Before contributing, make yourself familiar with [our contribution guidelines](https://developers.stoat.chat/developing/contrib/) and the [technical documentation for this project](https://stoatchat.github.io/stoatchat/).
+Before contributing, make yourself familiar with [our contribution guidelines](https://developers.stoat.chat/developing/contrib/) and the [technical documentation for this project](https://developers.stoat.chat/).
 
 Before getting started, you'll want to install:
 
@@ -212,6 +212,6 @@ TEST_DB=MONGODB cargo nextest run
 
 ## License
 
-The Stoat backend is generally licensed under the [GNU Affero General Public License v3.0](https://github.com/stoatchat/stoatchat/blob/master/LICENSE).
+The Stoat backend is generally licensed under the [GNU Affero General Public License v3.0](https://github.com/stoatchat/stoatchat/blob/main/LICENSE).
 
 **Individual crates may supply their own licenses!**

--- a/crates/delta/src/routes/mod.rs
+++ b/crates/delta/src/routes/mod.rs
@@ -216,7 +216,7 @@ fn custom_openapi_spec() -> OpenApi {
             }),
             license: Some(License {
                 name: "AGPLv3".to_owned(),
-                url: Some("https://github.com/revoltchat/delta/blob/master/LICENSE".to_owned()),
+                url: Some("https://github.com/stoatchat/stoatchat/blob/main/crates/delta/LICENSE".to_owned()),
                 ..Default::default()
             }),
             version: env!("CARGO_PKG_VERSION").to_string(),

--- a/docs/docs/developing/backend/new_features.md
+++ b/docs/docs/developing/backend/new_features.md
@@ -10,6 +10,6 @@ Before writing new API features, generally a good idea to:
 When your feature is ready to release, ensure to:
 
 - Update backend documentation (what you're reading now!) if applicable
-- Update the [developers documentation](https://github.com/stoatchat/developer-wiki) if applicable
+- Update the [developers documentation](https://github.com/stoatchat/stoatchat/tree/main/docs) if applicable
 - Update the Feature Matrix (or ask someone that can to do so)
 - Ensure it is properly listed in the backend release changelog

--- a/docs/docs/help.md
+++ b/docs/docs/help.md
@@ -13,7 +13,7 @@ We want to hear what you think and appreciate and await your feature suggestions
 
 Typically, you can open issues on the relevant [GitHub repositories](https://github.com/stoatchat).
 
-<!-- Within the Stoat app, you can navigate to the [**feedback tab**](https://app.revolt.chat/settings/feedback), or you can open an issue on the relevant [GitHub repo](https://github.com/revoltchat). -->
+<!-- Within the Stoat app, you can navigate to the [**feedback tab**](https://app.revolt.chat/settings/feedback), or you can open an issue on the relevant [GitHub repo](https://github.com/stoatchat). -->
 
 ### 2. Translate
 


### PR DESCRIPTION
Updates user-facing links to point to the new organization. Does not update references in source code (user-agent, dependency references), as they should be handled separately.

Edit: This seems to partially, but not fully, duplicate efforts in #612 