### PR TITLE
fix: Check for appropriate permission for removing other users avatar

### DIFF
--- a/crates/delta/src/routes/servers/member_edit.rs
+++ b/crates/delta/src/routes/servers/member_edit.rs
@@ -65,12 +65,10 @@ pub async fn edit(
     if data.avatar.is_some() || data.remove.contains(&v0::FieldsMember::Avatar) {
         if user.id == member.id.user {
             permissions.throw_if_lacking_channel_permission(ChannelPermission::ChangeAvatar)?;
+        } else if data.remove.contains(&v0::FieldsMember::Avatar) {
+            permissions.throw_if_lacking_channel_permission(ChannelPermission::RemoveAvatars)?;
         } else {
-            if data.remove.contains(&v0::FieldsMember::Avatar) {
-                permissions.throw_if_lacking_channel_permission(ChannelPermission::RemoveAvatars)?;
-            } else {
-                return Err(create_error!(InvalidOperation))
-            }
+            return Err(create_error!(InvalidOperation))
         }
     }
 


### PR DESCRIPTION
Fixes https://github.com/stoatchat/stoatchat/issues/641

Validated in local test environment - reproduced reported error pre-fix, successfully removed avatar from identify post-fix