### PR TITLE
fix: send push notifications for DM and group messages

### DIFF
--- a/crates/core/database/src/models/messages/model.rs
+++ b/crates/core/database/src/models/messages/model.rs
@@ -687,8 +687,13 @@ impl Message {
         )
         .await?;
 
+        let is_dm_or_group = matches!(
+            channel,
+            Channel::DirectMessage { .. } | Channel::Group { .. }
+        );
+
         if !self.has_suppressed_notifications()
-            && (self.mentions.is_some() || self.contains_mass_push_mention())
+            && (is_dm_or_group || self.mentions.is_some() || self.contains_mass_push_mention())
         {
             // send Push notifications
             #[cfg(feature = "tasks")]


### PR DESCRIPTION
DMs and group messages never trigger push notifications because the condition only checks for explicit @mentions or mass push mentions. Since DMs don't use @mentions, users never receive push notifications for direct messages.

Adds `is_dm_or_group` check so DM and Group channels always trigger push notifications (unless suppressed).