### PR TITLE
fix: uname is missing from crond

### DIFF
--- a/crates/core/config/src/lib.rs
+++ b/crates/core/config/src/lib.rs
@@ -454,7 +454,9 @@ pub async fn config() -> Settings {
     }
 
     // auto-detect production nodes
-    if config.hosts.api.contains("https") && config.hosts.api.contains("revolt.chat") {
+    if config.hosts.api.contains("https")
+        && (config.hosts.api.contains("revolt.chat") | config.hosts.api.contains("stoat.chat"))
+    {
         config.production = true;
     }
 

--- a/crates/daemons/crond/Dockerfile
+++ b/crates/daemons/crond/Dockerfile
@@ -5,6 +5,7 @@ FROM debian:12 AS debian
 # Bundle Stage
 FROM gcr.io/distroless/cc-debian12:nonroot
 COPY --from=builder /home/rust/src/target/release/revolt-crond ./
+COPY --from=debian /usr/bin/uname /usr/bin/uname
 
 USER nonroot
 CMD ["./revolt-crond"]


### PR DESCRIPTION
Adds uname back into the crond docker file. Also fixes the production check in the config crate since i noticed it.

- `main` <!-- branch-stack -->
  - \#675 :point\_left:
