### PR TITLE
chore: silence git town errors

### DIFF
--- a/.github/workflows/git-town.yml
+++ b/.github/workflows/git-town.yml
@@ -7,6 +7,7 @@ jobs:
   git-town:
     name: Display the branch stack
     runs-on: ubuntu-slim
+    continue-on-error: true
 
     if: ${{ !startsWith(github.head_ref, 'release-please--') }}
 


### PR DESCRIPTION
As per title, silence errors from the git town workflow.

- `main` <!-- branch-stack -->
  - \#686 :point\_left:
