### PR TITLE
chore: silence git town errors

### DIFF
--- a/.github/workflows/git-town.yml
+++ b/.github/workflows/git-town.yml
@@ -17,3 +17,4 @@ jobs:
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
       - uses: stoatchat/action-git-town@4bc5c942e4603bffa0806b51d5fe5f0bc5deb0ac
+        continue-on-error: true


### PR DESCRIPTION
as per title, silence git town errors in the pr actions

- `main` <!-- branch-stack -->
  - \#687 :point\_left:
