### PR TITLE
chore: add undeclared dependency to default.nix: cargo

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -19,6 +19,7 @@ in pkgs.mkShell {
   packages = with pkgs; [
     mise
     cargo-binstall
+    cargo
     (writeShellScriptBin "fish" ''
       exec ${pkgs.fish}/bin/fish -C 'mise activate fish | source' "$@"
     '')


### PR DESCRIPTION
Feel free to reject if there's a reason that cargo is not included in default.nix.

The reason for this PR is that the undeclared dependency frustrated me.