### PR TITLE
Update OpenAPI spec branding from Revolt to Stoat

### DIFF
--- a/crates/delta/src/routes/mod.rs
+++ b/crates/delta/src/routes/mod.rs
@@ -115,8 +115,8 @@ fn custom_openapi_spec() -> OpenApi {
     extensions.insert(
         "x-logo".to_owned(),
         json!({
-            "url": "https://revolt.chat/header.png",
-            "altText": "Revolt Header"
+            "url": "https://stoat.chat/header.png",
+            "altText": "Stoat Header"
         }),
     );
 
@@ -124,7 +124,7 @@ fn custom_openapi_spec() -> OpenApi {
         "x-tagGroups".to_owned(),
         json!([
           {
-            "name": "Revolt",
+            "name": "Stoat",
             "tags": [
               "Core"
             ]
@@ -205,13 +205,13 @@ fn custom_openapi_spec() -> OpenApi {
     OpenApi {
         openapi: OpenApi::default_version(),
         info: Info {
-            title: "Revolt API".to_owned(),
+            title: "Stoat API".to_owned(),
             description: Some("Open source user-first chat platform.".to_owned()),
-            terms_of_service: Some("https://revolt.chat/terms".to_owned()),
+            terms_of_service: Some("https://stoat.chat/terms".to_owned()),
             contact: Some(Contact {
-                name: Some("Revolt Support".to_owned()),
-                url: Some("https://revolt.chat".to_owned()),
-                email: Some("contact@revolt.chat".to_owned()),
+                name: Some("Stoat Support".to_owned()),
+                url: Some("https://stoat.chat".to_owned()),
+                email: Some("contact@stoat.chat".to_owned()),
                 ..Default::default()
             }),
             license: Some(License {
@@ -224,29 +224,24 @@ fn custom_openapi_spec() -> OpenApi {
         },
         servers: vec![
             Server {
-                url: "https://api.revolt.chat".to_owned(),
-                description: Some("Revolt Production".to_owned()),
+                url: "https://stoat.chat/api".to_owned(),
+                description: Some("Stoat Production".to_owned()),
                 ..Default::default()
             },
             Server {
-                url: "https://revolt.chat/api".to_owned(),
-                description: Some("Revolt Staging".to_owned()),
+                url: "http://local.stoat.chat:14702".to_owned(),
+                description: Some("Local Stoat Environment".to_owned()),
                 ..Default::default()
             },
             Server {
-                url: "http://local.revolt.chat:14702".to_owned(),
-                description: Some("Local Revolt Environment".to_owned()),
-                ..Default::default()
-            },
-            Server {
-                url: "http://local.revolt.chat:14702/0.8".to_owned(),
-                description: Some("Local Revolt Environment (v0.8)".to_owned()),
+                url: "http://local.stoat.chat:14702/0.8".to_owned(),
+                description: Some("Local Stoat Environment (v0.8)".to_owned()),
                 ..Default::default()
             },
         ],
         external_docs: Some(ExternalDocs {
-            url: "https://developers.revolt.chat".to_owned(),
-            description: Some("Revolt Developer Documentation".to_owned()),
+            url: "https://developers.stoat.chat".to_owned(),
+            description: Some("Stoat Developer Documentation".to_owned()),
             ..Default::default()
         }),
         extensions,
@@ -254,19 +249,19 @@ fn custom_openapi_spec() -> OpenApi {
             Tag {
                 name: "Core".to_owned(),
                 description: Some(
-                    "Use in your applications to determine information about the Revolt node"
+                    "Use in your applications to determine information about the Stoat node"
                         .to_owned(),
                 ),
                 ..Default::default()
             },
             Tag {
                 name: "User Information".to_owned(),
-                description: Some("Query and fetch users on Revolt".to_owned()),
+                description: Some("Query and fetch users on Stoat".to_owned()),
                 ..Default::default()
             },
             Tag {
                 name: "Direct Messaging".to_owned(),
-                description: Some("Direct message other users on Revolt".to_owned()),
+                description: Some("Direct message other users on Stoat".to_owned()),
                 ..Default::default()
             },
             Tag {
@@ -283,7 +278,7 @@ fn custom_openapi_spec() -> OpenApi {
             },
             Tag {
                 name: "Channel Information".to_owned(),
-                description: Some("Query and fetch channels on Revolt".to_owned()),
+                description: Some("Query and fetch channels on Stoat".to_owned()),
                 ..Default::default()
             },
             Tag {
@@ -313,7 +308,7 @@ fn custom_openapi_spec() -> OpenApi {
             },
             Tag {
                 name: "Server Information".to_owned(),
-                description: Some("Query and fetch servers on Revolt".to_owned()),
+                description: Some("Query and fetch servers on Stoat".to_owned()),
                 ..Default::default()
             },
             Tag {
@@ -349,7 +344,7 @@ fn custom_openapi_spec() -> OpenApi {
             Tag {
                 name: "Onboarding".to_owned(),
                 description: Some(
-                    "After signing up to Revolt, users must pick a unique username".to_owned(),
+                    "After signing up to Stoat, users must pick a unique username".to_owned(),
                 ),
                 ..Default::default()
             },
@@ -361,7 +356,7 @@ fn custom_openapi_spec() -> OpenApi {
             Tag {
                 name: "Web Push".to_owned(),
                 description: Some(
-                    "Subscribe to and receive Revolt push notifications while offline".to_owned(),
+                    "Subscribe to and receive Stoat push notifications while offline".to_owned(),
                 ),
                 ..Default::default()
             },


### PR DESCRIPTION
## Summary

The OpenAPI spec at `/swagger/index.html` still displays Revolt branding (title, contact info, server URLs, tag descriptions). This updates all user-facing strings in `custom_openapi_spec()` to use Stoat branding.

## Changes

**File:** `crates/delta/src/routes/mod.rs`

- API title: "Revolt API" -> "Stoat API"
- Contact: revolt.chat -> stoat.chat
- Server URLs: api.revolt.chat -> stoat.chat/api (per migration guide)
- External docs: developers.revolt.chat -> developers.stoat.chat
- Logo URL: revolt.chat/header.png -> stoat.chat/header.png
- Tag group: "Revolt" -> "Stoat"
- Tag descriptions: "on Revolt" -> "on Stoat" across 6 tags
- Consolidated duplicate staging server entry (old Revolt had separate staging URL)

Internal crate names (`revolt_rocket_okapi`, `revolt_database`, etc.) are unchanged - those are separate from the user-facing OpenAPI metadata.

## Testing

- Verified all `revolt` references in OpenAPI metadata strings are replaced (excluding internal crate imports)
- Server URLs match the [migration guide](https://github.com/stoatchat/stoatchat/blob/main/docs/docs/developers/stoat-migration-guide.md)

Closes #610

This contribution was developed with AI assistance (Claude Code).