### PR TITLE
docs(readme): remove outdated reference to `scripts/install.sh`; add instruction to run `mise install`

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,9 +131,6 @@ Then continue:
 # start other necessary services
 docker compose up -d
 
-# run everything together
-./scripts/start.sh
-# .. or individually
 # run the API server
 cargo run --bin revolt-delta
 # run the events server


### PR DESCRIPTION
Hello again. Here's the promised PR that adds any mention at all of `mise install` to the install instructions.