### PR TITLE
fix: don't send self dm notifications

### DIFF
--- a/crates/core/database/src/models/messages/model.rs
+++ b/crates/core/database/src/models/messages/model.rs
@@ -1,6 +1,4 @@
 use indexmap::{IndexMap, IndexSet};
-#[cfg(feature = "tasks")]
-use isahc::auth;
 use iso8601_timestamp::Timestamp;
 use revolt_config::{config, FeaturesLimits};
 use revolt_models::v0::{

--- a/crates/core/database/src/models/messages/model.rs
+++ b/crates/core/database/src/models/messages/model.rs
@@ -1,4 +1,6 @@
 use indexmap::{IndexMap, IndexSet};
+#[cfg(feature = "tasks")]
+use isahc::auth;
 use iso8601_timestamp::Timestamp;
 use revolt_config::{config, FeaturesLimits};
 use revolt_models::v0::{
@@ -705,7 +707,7 @@ impl Message {
                         Some(
                             PushNotification::from(
                                 self.clone().into_model(user, member),
-                                Some(author),
+                                Some(author.clone()),
                                 channel.to_owned().into(),
                             )
                             .await,
@@ -713,7 +715,11 @@ impl Message {
                         self.clone(),
                         match channel {
                             Channel::DirectMessage { recipients, .. }
-                            | Channel::Group { recipients, .. } => recipients.clone(),
+                            | Channel::Group { recipients, .. } => recipients
+                                .iter()
+                                .filter(|uid| *uid != author.id())
+                                .cloned()
+                                .collect(),
                             Channel::TextChannel { .. } => {
                                 self.mentions.clone().unwrap_or_default()
                             }

--- a/crates/core/models/src/v0/messages.rs
+++ b/crates/core/models/src/v0/messages.rs
@@ -391,6 +391,7 @@ auto_derived!(
 );
 
 /// Message Author Abstraction
+#[derive(Clone)]
 pub enum MessageAuthor<'a> {
     User(&'a User),
     Webhook(&'a Webhook),

--- a/crates/core/parser/src/lib.rs
+++ b/crates/core/parser/src/lib.rs
@@ -262,7 +262,7 @@ mod tests {
         )
         .collect::<Vec<_>>();
 
-        assert_eq!(output.len(), 6);
+        assert_eq!(output.len(), 7);
         assert_eq!(output[0], MessageToken::CodeblockMarker(1));
         assert_eq!(
             output[1],


### PR DESCRIPTION
Filter out the user from the dm/group recipients list to prevent attempting to send self notifications.

- `main` <!-- branch-stack -->
  - \#706 :point\_left:
