### PR TITLE
docs: add run in yaak button to endpoints page

### DIFF
--- a/docs/docs/developers/endpoints.md
+++ b/docs/docs/developers/endpoints.md
@@ -4,6 +4,8 @@ sidebar_position: 1
 
 # Endpoints
 
+[![Run in Yaak](https://external.stoatusercontent.com/proxy?url=https://yaak.app/static/button.svg)](https://yaak.app/button/run?name=Stoat+API&url=https%3A%2F%2Fstoat.chat%2Fapi%2Fopenapi.json)
+
 **We are moving stuff around currently following the rebrand, guidance will follow soon!**
 
 You can connect to the API on the following URLs:


### PR DESCRIPTION
Add a button to immediately import our OpenAPI definition in popular API client Yaak to aid in rapid iteration for client developers

<img width="514" height="265" alt="image" src="https://github.com/user-attachments/assets/e50f5f8b-6913-408c-bc86-b26067516b24" />
