### PR TITLE
Security: Self-referential HashMap extend in user_settings reference implementation

### DIFF
--- a/crates/core/database/src/models/user_settings/ops/reference.rs
+++ b/crates/core/database/src/models/user_settings/ops/reference.rs
@@ -25,8 +25,8 @@ impl AbstractUserSettings for ReferenceDb {
     /// Update a subset of user settings
     async fn set_user_settings(&self, id: &str, settings: &UserSettings) -> Result<()> {
         let mut user_settings = self.user_settings.lock().await;
-        if let Some(settings) = user_settings.get_mut(id) {
-            settings.extend(settings.clone());
+        if let Some(existing) = user_settings.get_mut(id) {
+            existing.extend(settings.clone());
         } else {
             user_settings.insert(id.to_string(), settings.clone());
         }


### PR DESCRIPTION
## Summary

Security: Self-referential HashMap extend in user_settings reference implementation

## Problem

**Severity**: `Medium` | **File**: `crates/core/database/src/models/user_settings/ops/reference.rs:L33`

In `crates/core/database/src/models/user_settings/ops/reference.rs`, the `set_user_settings` function contains a bug: it extends the stored settings map with itself (`settings.extend(settings.clone())`), which results in duplicate entries instead of properly merging settings. The correct logic should extend the existing stored settings with the new settings.

## Solution

Change the logic to properly merge new settings into existing ones:

```rust
async fn set_user_settings(&self, id: &str, settings: &UserSettings) -> Result<()> {
    let mut user_settings = self.user_settings.lock().await;
    if let Some(existing) = user_settings.get_mut(id) {
        existing.extend(settings.clone());
    } else {
        user_settings.insert(id.to_string(), settings.clone());
    }
    Ok(())
}
```

## Changes

- `crates/core/database/src/models/user_settings/ops/reference.rs` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced

---
*Generated by [ContribAI](https://github.com/tang-vu/ContribAI) v6.0.0*