### PR TITLE
fix: update message length validation to remove upper limit

### DIFF
--- a/crates/core/models/src/v0/messages.rs
+++ b/crates/core/models/src/v0/messages.rs
@@ -261,7 +261,7 @@ auto_derived!(
         pub nonce: Option<String>,
 
         /// Message content to send
-        #[cfg_attr(feature = "validator", validate(length(min = 0, max = 2000)))]
+        #[cfg_attr(feature = "validator", validate(length(min = 0)))]
         pub content: Option<String>,
         /// Attachments to include in message
         pub attachments: Option<Vec<String>>,
@@ -345,7 +345,7 @@ auto_derived!(
     #[cfg_attr(feature = "validator", derive(Validate))]
     pub struct DataEditMessage {
         /// New message content
-        #[cfg_attr(feature = "validator", validate(length(min = 1, max = 2000)))]
+        #[cfg_attr(feature = "validator", validate(length(min = 1)))]
         pub content: Option<String>,
         /// Embeds to include in the message
         #[cfg_attr(feature = "validator", validate(length(min = 0, max = 10)))]


### PR DESCRIPTION
<!-- Describe your changes -->
Removed the max = 2000 from serde validator as it was hard coded and would fail if a self host used a larger amount. Since there's already a Message::validate_length() this didn't break anything as far as I can see.

Fixes #725

## How was this PR tested?

<!-- What did you do to test your changes? -->

- [x] Sent a 2539 length message when feature limit was set to 3000

## Checklist:

- [x] I have carefully read [the contributing guidelines](https://developers.stoat.chat/developing/contrib/)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR
- [x] I have confirmed that any new dependencies are strictly necessary
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code

## Please declare, if any, LLM usage involved in creating this PR
No LLM used
